### PR TITLE
Allow 0/1 to be parsed as boolean

### DIFF
--- a/src/main/java/org/opendatakit/common/utils/WebUtils.java
+++ b/src/main/java/org/opendatakit/common/utils/WebUtils.java
@@ -176,6 +176,8 @@ public class WebUtils {
         b = Boolean.TRUE;
       } else if (value.compareToIgnoreCase("Y") == 0) {
         b = Boolean.TRUE;
+      } else if (value.compareToIgnoreCase("1") == 0) {
+        b = Boolean.TRUE;
       }
     }
     return b;


### PR DESCRIPTION
ODK Services emits 0/1 for boolean values, these values should be recognized properly by Sync Endpoint.