### PR TITLE
return all dataEtag since beginning or query, unordered

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/odktables/DataManager.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/DataManager.java
@@ -1601,9 +1601,11 @@ public class DataManager {
       
       Query query;
       if (unifiedSequenceValue == null) {
-        query = buildRowsFromBeginningQuery(logTable, entry, true);
+        query = logTable.query("DataManager.getChangesetsSinceBeginning", cc);
+        query.greaterThanOrEqual(DbLogTable.SEQUENCE_VALUE, entry.getAprioriDataSequenceValue());
       } else {
-        query = buildRowsSinceQuery(logTable, unifiedSequenceValue, true);
+        query = logTable.query("DataManager.getChangesetsSinceQuery", cc);
+        query.greaterThan(DbLogTable.SEQUENCE_VALUE, unifiedSequenceValue);
       }
       
       result = query.getDistinct(DbLogTable.DATA_ETAG_AT_MODIFICATION);


### PR DESCRIPTION
bugfix for [issue](https://github.com/opendatakit/opendatakit/issues/1417)

my fix  only returns the dataEtags in random order ,
still needs alphabetical sorting to be consistent with the documentation
